### PR TITLE
Extended to the wider net

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,12 @@ Open Source Day Flattr Chrome Extension
 
 This extension for Google Chrome displays a Flattr icon in the address field when the website you are on can be flattred. Clicking the icon takes you to the thing page on flattr.com!
 
+Recursive Search
+-------
+If no direct match is found, the base domain and up to 9 urls 'back' from the current URL will be searched in an attempt to find a flattr match. The extension options page allows the user turn off recursive search, control the depth of the recursion, and explains this concept in further detail.
+
 Testing
 -------
-
  1. Clone this repo.
  2. In Chrome: Tools -> Extensions.
  3. Click the + "Developer mode".

--- a/background.js
+++ b/background.js
@@ -1,25 +1,71 @@
-var url;
+// This script listens for new tab events and inspects the url for flattr'ability
+//
+// If a flattr thing is found, an icon is displayed in the browser url bar,
+//
+// When the icon in address field is clicked, we open the flattr.com thing page
+// in a new tab/window.
 
-// Listen for any changes to the URL of any tab. If URL
-// exists, we show our extension icon in the address field.
+// Global variables
+var furls = [];	    // associative object containing flattr'able urls
+var debug = false;  // log a bunch of debug info to the console
+var entries = 0;    // debug var to track the total # of urls checked via the API
+
+// debug logging
+function dlog(str) {
+	if (debug) {
+		console.log('entry:'+entries+' | '+str);
+	}
+}
+
+// Listen for any changes to the URL of any tab.
+// If URL exists, we show our extension icon in the address field.
 chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
-    if (isWhiteListed(tab.url)) {
-        if (isWikipedia(tab.url)) {
-            url = createWikipediaAutoSubmitUrl(tab.url, tab.title);
-            chrome.pageAction.show(tabId);
-        } else {
-            findFlattrThingForUrl(tab.url, function(thing) {
-                if (thing) {
-                    url = thing.link;
-                    chrome.pageAction.show(tabId);
-                }
-            });
-        }
-    }
+
+	// Take no action for non http urls
+	if (tab.url.indexOf('http') != 0) {
+		dlog('non http url:'+tab.url);
+		return;
+	}
+
+	// In order to avoid duplicate requests, wait until the tab load is complete
+	// http://code.google.com/chrome/extensions/tabs.html#event-onUpdated
+	if (changeInfo.status != 'complete') {
+		dlog('non complete tab status for:'+tab.url);
+		return;
+	}
+
+	tabUrl = stripHashes(tab.url);
+
+	if (isWikipedia(tabUrl)) {
+		furls[tabUrl] = createWikipediaAutoSubmitUrl(tabUrl, tab.title);
+		chrome.pageAction.show(tabId);
+	} else {
+		entries++; // debug
+
+		// Grab retries from browser storage, defaults to 5
+		// See ./options/index.html for documentation
+		retries = localStorage['retry_times'];
+		if (isNaN(retries) || retries < -1 || retries > 9) {
+			retries = 5;
+		}
+
+		// Call the flattr API (possibly recursively) to search for tabUrl
+		findFlattrThingForUrl(tabUrl, retries, function(thing) {
+			// callback function stores the link and sets the icon in the url bar
+			if (thing) {
+				furls[tabUrl] = thing.link;
+				chrome.pageAction.show(tabId);
+			}
+		});
+	}
 });
 
-// When the icon in address field is clicked, we open the flattr.com
-// thing page in a new tab/window.
+// When the icon in address field is clicked, we
+// open the flattr.com thing page in a new tab/window.
 chrome.pageAction.onClicked.addListener(function (tab) {
-    window.open(url);
+	// pull the appropriate flattr url from the global array
+	furl = furls[stripHashes(tab.url)];
+	if (furl) {
+		window.open(furl);
+	}
 });

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,9 @@
 {
   "manifest_version": 2,
   "name": "Flattr",
-  "version": "0.6",
-  "description": "Displays a flattr button for Wikipedia and other popular sites that do not have flattr buttons visible",
+  "version": "0.7",
+  "description": "Displays a flattr button for Wikipedia and other sites that do not have flattr buttons visible",
+  "options_page": "options/index.html",
   "background_page": "background.html",
   "page_action": {
     "default_icon": "icon_128.png",

--- a/util.js
+++ b/util.js
@@ -1,83 +1,121 @@
-var WHITELIST = [
-    "wikipedia.org",
-    "twitter.com",
-    "youtube.com",
-    "youtify.com",
-    "jamendo.com",
-    "soundcloud.com",
-    "grooveshark.com",
-    "kahvi.org",
-    "github.com",
-    "sourceforge.net",
-    "flattr.com"
-];
+// Utility functions used to help determine flattr'ability
 
 function getFlattrLangCodeForWikipediaUrl(url) {
-    var ret = 'en_GB';
-    var map = {
-        'en': 'en_GB',
-        'es': 'es_ES',
-        'de': 'de_DE',
-        'fr': 'fr_FR',
-        'it': 'it_IT',
-        'pt': 'pt_PT',
-        'pl': 'pl_PL',
-        'ja': 'ja_JP',
-        'ru': 'ru_RU',
-        'zh': 'zh_CN',
-        'sv': 'sv_SE',
-        'dk': 'da_DK',
-        'fi': 'fi_FI',
-        'no': 'no_NO',
-    };
+	var ret = 'en_GB';
+	var map = {
+		'en': 'en_GB',
+		'es': 'es_ES',
+		'de': 'de_DE',
+		'fr': 'fr_FR',
+		'it': 'it_IT',
+		'pt': 'pt_PT',
+		'pl': 'pl_PL',
+		'ja': 'ja_JP',
+		'ru': 'ru_RU',
+		'zh': 'zh_CN',
+		'sv': 'sv_SE',
+		'dk': 'da_DK',
+		'fi': 'fi_FI',
+		'no': 'no_NO',
+	};
 
-    try {
-        var langCode = url.match("(http|https)://(.*)\.(wikipedia.org)")[2];
-        if (langCode in map) {
-            ret = map[langCode];
-        }
-    } catch (e) {
-    }
+	try {
+		var langCode = url.match('(http|https)://(.*)\.(wikipedia.org)')[2];
+		if (langCode in map) {
+			ret = map[langCode];
+		}
+	} catch (e) { }
 
-    return ret;
+	return ret;
 }
 
 function createWikipediaAutoSubmitUrl(url, title) {
-    return "https://flattr.com/submit/auto?user_id=WikimediaFoundation&url=" + encodeURIComponent(url) + "&title=" + encodeURIComponent(title) + "&language=" + getFlattrLangCodeForWikipediaUrl(url) + "&tags=wikipedia,article&hidden=0&category=text";
+	return 'https://flattr.com/submit/auto?user_id=WikimediaFoundation&url=' + encodeURIComponent(url) + '&title=' + encodeURIComponent(title) + '&language=' + getFlattrLangCodeForWikipediaUrl(url) + '&tags=wikipedia,article&hidden=0&category=text';
 }
 
 function isWikipedia(url) {
-    return url.match("(http|https)://(.*\.)?(wikipedia.org)");
+	return url.match('(http|https)://(.*\.)?(wikipedia.org)');
 }
 
-function isWhiteListed(url) {
-    var i = 0,
-        domain;
-
-    for (i = 0; i < WHITELIST.length; i += 1) {
-        domain = WHITELIST[i];
-        if (url.match("(http|https)://(.*?\.)?(" + domain + ")")) {
-            return true;
-        }
-    }
-
-    return false;
+// Strip hash anchors - they broke the furls array when used for an index
+// also, arguably better for wikipedia, at least from a load standpoint
+function stripHashes(url) {
+	hashLoc = url.indexOf('#')
+	if (hashLoc != -1) {
+		return url.substring(0,hashLoc);
+	}
+	return url;
 }
 
-function findFlattrThingForUrl(url, callback) {
-    var xhr = new XMLHttpRequest(),
-        lookupUrl = 'https://api.flattr.com/rest/v2/things/lookup?q=' + encodeURIComponent(url);
+/*
+ * This is a recursive function which queries the flattr API for the 'url' param
+ * The base case is recRetries < 0, in which case the callback is exec'd
+ * When recRetries = 0, the root url of the domain is tested for flattr'ability
+ * When recRetries > 1, the function will recurse until a match is found
+*/
+function findFlattrThingForUrl(url, recRetries, callback) {
+	var xhr = new XMLHttpRequest(),
+	lookupUrl = 'https://api.flattr.com/rest/v2/things/lookup?q=' +
+	encodeURIComponent(url);
 
-    xhr.open("GET", lookupUrl, true); // HEAD makes a 400 Bad Request...
-    xhr.onreadystatechange = function() {
-        if (xhr.readyState == 4 && xhr.status == 200 || xhr.status == 304) {
-            var response = JSON.parse(xhr.responseText);
-            if (response.message !== "not_found") {
-                callback(response);
-            } else {
-                callback(false);
-            }
-        }
-    };
-    xhr.send();
+	xhr.open('GET', lookupUrl, true); // HEAD makes a 400 Bad Request...
+	dlog('requesting:'+lookupUrl);
+
+	// When the API call returns
+	xhr.onreadystatechange = function() {
+
+		if (xhr.readyState == 4 && xhr.status == 200 || xhr.status == 304) {
+			var response = JSON.parse(xhr.responseText);
+
+			// If we have a match, we're done, callback to show the plugin icon
+			if (response.message !== 'not_found') {
+				dlog('match on:'+url);
+				callback(response);
+			} else {
+				// Recursion base case; no match found, so no-op
+				if (recRetries < 0) {
+					callback(false);
+				}
+
+				// Make the final recursive call with the root domain url
+				if (0 == recRetries) {
+					recRetries--;
+					// grab the root of the url
+					root = url.match('^https?://.*?/');
+
+					// If no domain was found, or the root was already looked up
+					if (!root || root == url) {
+						return callback(false);
+					}
+
+					// Make the final recursive call with the domain root
+					dlog('recRetries:'+recRetries+' | root:'+root);
+					findFlattrThingForUrl(root, recRetries, callback);
+				}
+
+				// Recurse to find a flattr'able url one level up
+				if (recRetries > 0) {
+					recRetries--;
+					domain = url;
+					if (url.indexOf('https://') == 0) {
+						domain = url.substring(8);
+					}
+					if (url.indexOf('http://') == 0) {
+						domain = url.substring(7);
+					}
+					parts = domain.split('/');
+					numParts = parts.length - 1;
+					if (numParts > 0) {
+						searchUrl = url.substring(
+							0, url.lastIndexOf(parts[numParts]) - 1
+						);
+						dlog('recRetries:'+recRetries+' | recurse:'+searchUrl);
+						// Make a recursive call with the trimmed url
+						findFlattrThingForUrl(searchUrl, recRetries, callback);
+					}
+				}
+			}
+		}
+	};
+	xhr.send();
 }


### PR DESCRIPTION
This plugin will now search for flattr'able urls anywhere on the net, as opposed to specific whitelisted sites. There are a couple of bug fixes, and a new barebones extension options page, where the level of recursion can be specified. The defaults can easily be changed within the code, and it would also be easy to add the concept of the whitelist back in as an option. 
