### PR TITLE
Added accidentally dropped options page, fixed a bug which had broken twitter things

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,4 +1,4 @@
-// This script listens for new tab events and inspects the url for flattr'ability
+// This script listens for new tab events & inspects the url for flattr'ability
 //
 // If a flattr thing is found, an icon is displayed in the browser url bar,
 //
@@ -6,9 +6,9 @@
 // in a new tab/window.
 
 // Global variables
-var furls = [];	    // associative object containing flattr'able urls
-var debug = false;  // log a bunch of debug info to the console
-var entries = 0;    // debug var to track the total # of urls checked via the API
+var furls = [];		// associative object containing flattr'able urls
+var debug = false;	// log a bunch of debug info to the console
+var entries = 0;	// debug var to track total # of urls checked via the API
 
 // debug logging
 function dlog(str) {
@@ -34,10 +34,10 @@ chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
 		return;
 	}
 
-	tabUrl = stripHashes(tab.url);
-
-	if (isWikipedia(tabUrl)) {
-		furls[tabUrl] = createWikipediaAutoSubmitUrl(tabUrl, tab.title);
+	if (isWikipedia(tab.url)) {
+		// strip hashes for wikipedia urls, results in one flattr thing per page
+		furls[escape(tab.url)] =
+			createWikipediaAutoSubmitUrl(stripHashes(tab.url), tab.title);
 		chrome.pageAction.show(tabId);
 	} else {
 		entries++; // debug
@@ -49,11 +49,11 @@ chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
 			retries = 5;
 		}
 
-		// Call the flattr API (possibly recursively) to search for tabUrl
-		findFlattrThingForUrl(tabUrl, retries, function(thing) {
-			// callback function stores the link and sets the icon in the url bar
+		// Call the flattr API (possibly recursively) to search for tab.url
+		findFlattrThingForUrl(tab.url, retries, function(thing) {
+			// callback function stores the link & sets the icon in the url bar
 			if (thing) {
-				furls[tabUrl] = thing.link;
+				furls[escape(tab.url)] = thing.link;
 				chrome.pageAction.show(tabId);
 			}
 		});
@@ -64,7 +64,7 @@ chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
 // open the flattr.com thing page in a new tab/window.
 chrome.pageAction.onClicked.addListener(function (tab) {
 	// pull the appropriate flattr url from the global array
-	furl = furls[stripHashes(tab.url)];
+	furl = furls[escape(tab.url)];
 	if (furl) {
 		window.open(furl);
 	}

--- a/options/index.html
+++ b/options/index.html
@@ -1,0 +1,90 @@
+<html>
+	<head>
+		<title>Flattr Chrome Extension Options</title>
+		<script>
+
+			// Saves options to localStorage.
+			function save_options() {
+				var select = document.getElementById('retries');
+				var retries = select.children[select.selectedIndex].value;
+				localStorage['retry_times'] = retries;
+
+				// Update status to let user know options were saved.
+				var status = document.getElementById('status');
+				status.innerHTML = ' Options Saved.';
+				setTimeout(function() { status.innerHTML = ''; }, 2000);
+			}
+
+			// Restores select box state to saved value from localStorage.
+			function restore_options() {
+				var retries = localStorage['retry_times'];
+				if (!retries) {
+					return;
+				}
+				var select = document.getElementById('retries');
+				for (var i = 0; i < select.children.length; i++) {
+					var child = select.children[i];
+					if (child.value == retries) {
+						child.selected = 'true';
+						break;
+					}
+				}
+			}
+
+		</script>
+
+		<body onload="restore_options()">
+
+			<h2><a href="https://chrome.google.com/webstore/detail/opjnhfkbdoopgfbefgbdkpjnbghffmln">Flattr Chrome Extension</a> Options</h2>
+			<p> Levels to Retry:
+			<select id="retries">
+				<option value="-1">-1 (direct match only)</option>
+				<option value="0">0 (direct or domain match)</option>
+				<option value="1">1 </option>
+				<option value="2">2 </option>
+				<option value="3">3 </option>
+				<option value="4">4 </option>
+				<option value="5" selected>5 </option>
+				<option value="6">6 </option>
+				<option value="7">7 </option>
+				<option value="8">8 </option>
+				<option value="9">9 </option>
+			</select>
+			</p>
+			<button onclick="save_options()">Save</button><b id="status"> </b>
+			<br /><br />
+			<table border="1" style="text-align:center;">
+				<tr><th>Retries</th><th>Result</th></tr>
+				<tr>
+					<td>-1</td>
+					<td>Only display on a direct flattr url match</td>
+					</tr><tr>
+					<td>0</td>
+					<td>Check domain root for a flattr thing if no 1:1 url match</td>
+					</tr><tr>
+					<td>&gt; 0</td>
+					<td>Check for a match &lt;Retries&gt; levels in from original url</td>
+				</tr>
+			</table>
+			<h3>Example</h3>
+			<p><em>Retries = 2 for request url: 
+				http://github.com/uname/project/api/model/user.php</em></p>
+			<table border="1" style="text-align:center;">
+				<tr><th>Retry #</th><th>Search flattr for URL</th></tr>
+				<tr>
+					<td>Original (-1)</td>
+					<td>http://github.com/uname/project/api/model/user.php</td>
+				</tr>
+				<tr>
+					<td>2</td>
+					<td>http://github.com/uname/project/api/model</td>
+					</tr><tr>
+					<td>1</td>
+					<td>http://github.com/uname/project/api</td>
+					</tr><tr>
+					<td>0</td>
+					<td>http://github.com (0 is always the domain root url)</td>
+				</tr>
+			</table>
+		</body>
+	</html>

--- a/util.js
+++ b/util.js
@@ -37,8 +37,8 @@ function isWikipedia(url) {
 	return url.match('(http|https)://(.*\.)?(wikipedia.org)');
 }
 
-// Strip hash anchors - they broke the furls array when used for an index
-// also, arguably better for wikipedia, at least from a load standpoint
+// Cuts off a string at the first hash character
+// (works fine for wikipedia, not good for twitter and others)
 function stripHashes(url) {
 	hashLoc = url.indexOf('#')
 	if (hashLoc != -1) {


### PR DESCRIPTION
This extension no longer strips url hashes unless the site is wikipedia. I realized this functionality broke the extension for twitter (and any other sites using hashes somewhere else in the url).
